### PR TITLE
Add clone to PublicKey

### DIFF
--- a/src/keytype.rs
+++ b/src/keytype.rs
@@ -1,7 +1,7 @@
 use super::error::{Error, ErrorKind, Result};
 use std::fmt;
 /// A type which represents the various kinds of keys.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum KeyTypeKind {
     /// Represents an RSA key type.
     Rsa,
@@ -35,7 +35,7 @@ pub enum KeyTypeKind {
 }
 
 /// `KeyType` represents the type of an OpenSSH key.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct KeyType {
     /// Name of the key type.
     pub name: &'static str,

--- a/src/pubkey.rs
+++ b/src/pubkey.rs
@@ -13,7 +13,7 @@ use base64;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 
 /// A type which represents the different kinds a public key can be.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum PublicKeyKind {
     /// Represents an RSA public key.
     Rsa(RsaPublicKey),
@@ -30,7 +30,7 @@ pub enum PublicKeyKind {
 
 /// RSA public key.
 /// The format of RSA public keys is described in RFC 4253, section 6.6
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct RsaPublicKey {
     /// Exponent of key.
     pub e: Vec<u8>,
@@ -41,7 +41,7 @@ pub struct RsaPublicKey {
 
 /// DSA public key.
 /// The format of DSA public keys is described in RFC 4253, section 6.6
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct DsaPublicKey {
     /// Parameter `p`.
     pub p: Vec<u8>,
@@ -57,7 +57,7 @@ pub struct DsaPublicKey {
 }
 
 /// Represents the different kinds of supported curves.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum CurveKind {
     /// Represents a NIST P-256 curve.
     Nistp256,
@@ -70,7 +70,7 @@ pub enum CurveKind {
 }
 
 /// A type which represents a cryptographic curve.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Curve {
     /// The curve kind.
     pub kind: CurveKind,
@@ -111,7 +111,7 @@ impl Curve {
 
 /// ECDSA public key.
 /// The format of ECDSA public keys is described in RFC 5656, section 3.1.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct EcdsaPublicKey {
     /// The curve being used.
     pub curve: Curve,
@@ -125,7 +125,7 @@ pub struct EcdsaPublicKey {
 
 /// ED25519 public key.
 /// The format of ED25519 public keys is described in https://tools.ietf.org/html/draft-bjh21-ssh-ed25519-02
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Ed25519PublicKey {
     /// The public key.
     pub key: Vec<u8>,
@@ -135,7 +135,7 @@ pub struct Ed25519PublicKey {
 }
 
 /// A type which represents an OpenSSH public key.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PublicKey {
     /// Key type.
     pub key_type: KeyType,


### PR DESCRIPTION
This adds the derive clone trait to PublicKey and other types to allow cloning. 