### PR TITLE
upgrade base64 to 0.22 and sha2 to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ categories = ["cryptography", "parser-implementations", "encoding"]
 license-file = "LICENSE"
 
 [dependencies]
-base64 = "0.12.1"
+base64 = "0.22"
 byteorder = "1.3.4"
-sha2 = "0.8.1"
+sha2 = "0.10"
 serde = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -10,6 +10,7 @@ use super::pubkey::PublicKey;
 use super::reader::Reader;
 
 use base64;
+use base64::Engine;
 
 /// Represents the different types a certificate can be.
 #[derive(Debug, PartialEq)]
@@ -130,7 +131,7 @@ impl Certificate {
             .ok_or(Error::with_kind(ErrorKind::InvalidFormat))?;
 
         let comment = iter.next().map(|v| String::from(v));
-        let decoded = base64::decode(&data)?;
+        let decoded = base64::engine::general_purpose::STANDARD.decode(&data)?;
         let mut reader = Reader::new(&decoded);
 
         // Validate key types before reading the rest of the data

--- a/src/pubkey.rs
+++ b/src/pubkey.rs
@@ -9,6 +9,7 @@ use super::reader::Reader;
 use super::writer::Writer;
 
 use base64;
+use base64::Engine;
 
 use sha2::{Digest, Sha256, Sha384, Sha512};
 
@@ -158,7 +159,7 @@ impl fmt::Display for PublicKey {
             f,
             "{} {} {}",
             self.key_type,
-            base64::encode(&self.encode()),
+            base64::engine::general_purpose::STANDARD.encode(&self.encode()),
             comment
         )
     }
@@ -225,7 +226,7 @@ impl Fingerprint {
             FingerprintKind::Sha512 => Sha512::digest(&data.as_ref()).to_vec(),
         };
 
-        let mut encoded = base64::encode(&digest);
+        let mut encoded = base64::engine::general_purpose::STANDARD.encode(&digest);
 
         // Trim padding characters from end
         let hash = match encoded.find('=') {
@@ -285,7 +286,7 @@ impl PublicKey {
 
         let kt = KeyType::from_name(&kt_name)?;
 
-        let decoded = base64::decode(&data)?;
+        let decoded = base64::engine::general_purpose::STANDARD.decode(&data)?;
         let mut reader = Reader::new(&decoded);
 
         // Validate key type before reading rest of the data
@@ -516,7 +517,7 @@ impl PublicKey {
     /// ```
     pub fn write<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
         let encoded = self.encode();
-        let data = base64::encode(&encoded);
+        let data = base64::engine::general_purpose::STANDARD.encode(&encoded);
         match self.comment {
             Some(ref c) => w.write_fmt(format_args!("{} {} {}\n", self.key_type.name, data, c)),
             None => w.write_fmt(format_args!("{} {}\n", self.key_type.name, data)),

--- a/tests/keys.rs
+++ b/tests/keys.rs
@@ -793,7 +793,8 @@ fn test_ed25519_host_cert() {
 
 #[test]
 pub fn test_ecdsa_sk_sha2_nistp256_pubkey() {
-    let key = sshkeys::PublicKey::from_path("tests/test-keys/id_ecdsa_sk_sha2_nistp256.pub").unwrap();
+    let key =
+        sshkeys::PublicKey::from_path("tests/test-keys/id_ecdsa_sk_sha2_nistp256.pub").unwrap();
 
     assert_eq!(key.key_type.name, "sk-ecdsa-sha2-nistp256@openssh.com");
     assert_eq!(key.key_type.plain, "sk-ecdsa-sha2-nistp256@openssh.com");
@@ -830,7 +831,6 @@ pub fn test_ecdsa_sk_sha2_nistp256_pubkey() {
     assert_eq!(ecdsa.curve.identifier, "nistp256");
     assert_eq!(ecdsa.curve.kind, sshkeys::CurveKind::Nistp256);
 }
-
 
 #[test]
 pub fn test_ed25519_sk_pubkey() {


### PR DESCRIPTION
ref: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/sshkeys/debian/patches/relax-deps.patch?ref_type=heads