### PR TITLE
Fix hidden elided lifetime in reader.rs

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -21,7 +21,7 @@ impl<'a> Reader<'a> {
     /// let num = reader.read_u32().unwrap();
     /// assert_eq!(num, 42);
     /// ```
-    pub fn new<T: ?Sized + AsRef<[u8]>>(inner: &T) -> Reader {
+    pub fn new<T: ?Sized + AsRef<[u8]>>(inner: &T) -> Reader<'_> {
         Reader {
             inner: inner.as_ref(),
             offset: 0,


### PR DESCRIPTION
This is a warning being produced on newer versions of Rust:
```
error: hiding a lifetime that's elided elsewhere is confusing
  --> /var/tmp/portage/net-nds/kanidm-clients-1.7.3/work/rust-sshkeys-d736693769b9c4abebad8050fba92271f3c50226/src/reader.rs:24:48
   |
24 |     pub fn new<T: ?Sized + AsRef<[u8]>>(inner: &T) -> Reader {
   |                                                ^^     ------ the same lifetime is hidden here
   |                                                |
   |                                                the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
note: the lint level is defined here
  --> /var/tmp/portage/net-nds/kanidm-clients-1.7.3/work/rust-sshkeys-d736693769b9c4abebad8050fba92271f3c50226/src/lib.rs:1:9
   |
1  | #![deny(warnings)]
   |         ^^^^^^^^
   = note: `#[deny(mismatched_lifetime_syntaxes)]` implied by `#[deny(warnings)]`
help: use `'_` for type paths
   |
24 |     pub fn new<T: ?Sized + AsRef<[u8]>>(inner: &T) -> Reader<'_> {
   |                                                             ++++
```